### PR TITLE
Encountered ValueError when calling nn.sparse_softmax_cross_entropy_w…

### DIFF
--- a/2_mnist.ipynb
+++ b/2_mnist.ipynb
@@ -147,7 +147,7 @@
     "    # Create an operation that calculates loss.\n",
     "    labels = tf.to_int64(labels)\n",
     "    cross_entropy = tf.nn.sparse_softmax_cross_entropy_with_logits(\n",
-    "        logits, labels, name='xentropy')\n",
+    "        labels=labels, logits=logits, name='xentropy')\n",
     "    loss = tf.reduce_mean(cross_entropy, name='xentropy_mean')\n",
     "    # Create the gradient descent optimizer with the given learning rate.\n",
     "    optimizer = tf.train.GradientDescentOptimizer(learning_rate)\n",


### PR DESCRIPTION
Got the error message that says "only call `sparse_softmax_cross_entropy_with_logits` with named arguments (labels=...,  logits=...,). 

![error running sparse_softmax_cross_entropy_with_logits](https://user-images.githubusercontent.com/1720122/27976680-7190c53e-631c-11e7-8539-e2d157952941.png)


Running on TensorFlow 1.2.1 and Python 2.7.12 
